### PR TITLE
Improve deployment docs and add license

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Environment variables for Syndic Management System
+
+# PostgreSQL connection URL
+DATABASE_URL="postgresql://username:password@localhost:5432/syndic"
+
+# Direct connection URL for Prisma
+DIRECT_URL="postgresql://username:password@localhost:5432/syndic"
+
+# Node environment
+NODE_ENV=development
+
+# Secret used to sign JWT tokens
+JWT_SECRET="change-me"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Syndic Management System
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ npm install
 # إنشاء ملف البيئة
 cp .env.example .env
 
-# تحديث متغيرات قاعدة البيانات في .env
+# تحديث متغيرات البيئة في .env
 DATABASE_URL="postgresql://username:password@host:port/database"
 DIRECT_URL="postgresql://username:password@host:port/database"
+JWT_SECRET="your-secret-key"
+NODE_ENV=development
 
 # إنشاء قاعدة البيانات
 npx prisma db push
@@ -90,6 +92,16 @@ npm run db:seed
 4. **تشغيل التطبيق**
 ```bash
 npm run dev
+```
+
+5. **بناء النسخة النهائية**
+```bash
+npm run build
+```
+
+6. **معاينة النسخة النهائية**
+```bash
+npm run preview
 ```
 
 ## بيانات تسجيل الدخول التجريبية
@@ -128,7 +140,7 @@ src/
 
 ## الترخيص
 
-هذا المشروع مرخص تحت رخصة MIT.
+هذا المشروع مرخص تحت رخصة MIT. راجع ملف `LICENSE` للمزيد من التفاصيل.
 
 ## الدعم
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "syndic-management-system",
   "private": true,
   "version": "1.0.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- document required environment variables
- add build and preview steps in README
- include MIT license file
- add license metadata to package.json

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685160b03278832f85e2fe5e27c2892a